### PR TITLE
Fix build error: Fatal error compiling: invalid target release: 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </licenses>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <jersey.version>2.34</jersey.version>
     <junit.version>5.7.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
For some reasons I received the following message when building:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project java-docker-build: Fatal error compiling: invalid target release: 11 -> [Help 1]
```

This PR fixes the build.
